### PR TITLE
Multi-binder inputs

### DIFF
--- a/multi-binder-samples/multi-binder-kafka-rabbit/src/main/java/multibinder/MultibinderApplication.java
+++ b/multi-binder-samples/multi-binder-kafka-rabbit/src/main/java/multibinder/MultibinderApplication.java
@@ -34,19 +34,34 @@ public class MultibinderApplication {
 		SpringApplication.run(MultibinderApplication.class, args);
 	}
 
-	@Bean
-	public Function<String, String> process() {
-		return payload -> payload.toUpperCase();
-	}
-
-	static class TestProducer {
+	static class TestProducerOldSystem {
 
 		private AtomicBoolean semaphore = new AtomicBoolean(true);
 
 		@Bean
-		public Supplier<String> sendTestData() {
-			return () -> this.semaphore.getAndSet(!this.semaphore.get()) ? "foo" : "bar";
+		public Supplier<String> sendTestDataOldSystem() {
+			return () -> this.semaphore.getAndSet(!this.semaphore.get()) ? "fooKafka" : "barKafka";
 		}
+	}
+
+	static class TestProducerNewSystem {
+
+		private AtomicBoolean semaphore = new AtomicBoolean(true);
+
+		@Bean
+		public Supplier<String> sendTestDataNewSystem() {
+			return () -> this.semaphore.getAndSet(!this.semaphore.get()) ? "fooRabbit" : "barRabbit";
+		}
+	}
+
+	@Bean
+	public Function<String, String> processOldSystem() {
+		return payload -> payload.toUpperCase();
+	}
+
+	@Bean
+	public Function<String, String> processNewSystem() {
+		return processOldSystem();
 	}
 
 	static class TestConsumer {

--- a/multi-binder-samples/multi-binder-kafka-rabbit/src/main/resources/application.yml
+++ b/multi-binder-samples/multi-binder-kafka-rabbit/src/main/resources/application.yml
@@ -2,20 +2,34 @@ spring:
   cloud:
     stream:
       bindings:
-        process-in-0:
+
+        # This represents your existing in-house system processor
+        processOldSystem-in-0:
           destination: dataIn
           binder: kafka
-        process-out-0:
+        processOldSystem-out-0:
           destination: dataOut
           binder: rabbit
+
+        # This represents your new (Pulsar custom binder) system processor
+        processNewSystem-in-0:
+          destination: dataIn
+          binder: rabbit
+        processNewSystem-out-0:
+          destination: dataOut
+          binder: rabbit
+
         #Test sink binding (used for testing)
-        sendTestData-out-0:
+        sendTestDataOldSystem-out-0:
           destination: dataIn
           binder: kafka
+        sendTestDataNewSystem-out-0:
+          destination: dataIn
+          binder: rabbit
         #Test sink binding (used for testing)
         receive-in-0:
           destination: dataOut
           binder: rabbit
-      function:
-        definition: sendTestData;process;receive
 
+      function:
+        definition: sendTestDataOldSystem;sendTestDataNewSystem;processOldSystem;processNewSystem;receive


### PR DESCRIPTION

### Reactive approach

To bind multiple inputs to a processor, you can use Reactor and change your function signature as described [here](https://docs.spring.io/spring-cloud-stream/docs/3.1.0/reference/html/spring-cloud-stream.html#_functions_with_multiple_input_and_output_arguments). 

> [!CAUTION]
> However, this highly violates this requirement in your use case:
> 
> "We need to transparently move them with only config changes as much as possible."

Plus it is a **big change** going to Reactive just for this temporary requirement.

### Softer approach

What I would instead do is create another temporary function in your code that just calls to the original processor. Then you can bind each to its own binder input. 

I did just that here in this PR. It takes the existing multi-binder sample that takes input from kafka and send it out to rabbit and tweaks it as follows...

- the "old system" represents your in-house message system (and is manifested by Kafka in this sample)
- the "new system" represents your new message system (which is Pulsar and is manifested by Rabbit in this sample)

The app binds 2 suppliers that feed messages (alternating between "foo|bar") into each old and new system.

The app has 2 processors (one for each binder old and new) and one just calls the other. The idea being that you can remove the newly added "proxy" function once all is well and the migration is complete. 

Finally, both processors output to a test receiver that containers messages from both systems. You can adjust this as necessary. 

Follow these exact steps to run the sample.
```
git clone https://github.com/onobc/spring-cloud-stream-samples.git

cd spring-cloud-stream-samples

git checkout cbono-apurva-multi-binder

cd multi-binder-samples/multi-binder-kafka-rabbit

./mvnw clean install -DskipTests

docker-compose up -d

java -jar target/multi-binder-kafka-rabbit-0.0.1-SNAPSHOT.jar
```

You will see something like...
```
1-be63-2f32d009f9a9] Resetting offset for partition dataIn-0 to offset 1.
2024-04-26 20:15:27.789  INFO 44945 --- [container-0-C-1] o.s.c.s.b.k.KafkaMessageChannelBinder$2  : anonymous.59b08ba8-f31e-4211-be63-2f32d009f9a9: partitions assigned: [dataIn-0]
2024-04-26 20:15:28.322  INFO 44945 --- [_-zxLW013n0Tw-1] m.MultibinderApplication$TestConsumer    : Data received...BARRABBIT
2024-04-26 20:15:28.354  INFO 44945 --- [_-zxLW013n0Tw-1] m.MultibinderApplication$TestConsumer    : Data received...BARKAFKA
2024-04-26 20:15:29.353  INFO 44945 --- [_-zxLW013n0Tw-1] m.MultibinderApplication$TestConsumer    : Data received...FOORABBIT
2024-04-26 20:15:29.372  INFO 44945 --- [_-zxLW013n0Tw-1] m.MultibinderApplication$TestConsumer    : Data received...FOOKAFKA
2024-04-26 20:15:30.336  INFO 44945 --- [_-zxLW013n0Tw-1] m.MultibinderApplication$TestConsumer    : Data received...BARRABBIT
2024-04-26 20:15:30.343  INFO 44945 --- [_-zxLW013n0Tw-1] m.MultibinderApplication$TestConsumer    : Data received...BARKAFKA
2024-04-26 20:15:31.353  INFO 44945 --- [_-zxLW013n0Tw-1] m.MultibinderApplication$TestConsumer    : Data received...FOORABBIT
2024-04-26 20:15:31.360  INFO 44945 --- [_-zxLW013n0Tw-1] m.MultibinderApplication$TestConsumer    : Data received...FOOKAFKA
```
Of course you can do this in your IDE too.

